### PR TITLE
Code always causes a deadlock.

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -1367,7 +1367,7 @@ mutex.signal()
 critical point
 \end{lstlisting}
 
-This turns out to be a bad idea because it can cause a
+This turns out to be a bad idea because it causes a
 deadlock.
 
 Imagine that the first thread enters the


### PR DESCRIPTION
I believe the code always causes a deadlock, thus changed the wordings.