### PR TITLE
fixed variable name in text to agree with example code

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -599,7 +599,7 @@ Now consider the following execution path
 \[  a1 < b1 < b2 < a2  \]
 
 Assuming that the
-initial value of {\tt x} is {\tt 0},
+initial value of {\tt count} is {\tt 0},
 what is its final value?  Because
 both threads read the same initial value, they write
 the same value.  The variable is only incremented once, which


### PR DESCRIPTION
The text in section 1.5.2 mentions an `x` variable. There is no `x` in the preceding code, but there is `count`.