### PR TITLE
added missing word: `sure`

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -3767,7 +3767,7 @@ sigmals that a barber has accepted payment.
 \subsection {Hilzer's barbershop solution}
 
 This solution is considerably more complex than I expected.  I
-am not if Hilzer had something simpler in mind, but here is the
+am not sure if Hilzer had something simpler in mind, but here is the
 best I could do.
 
 \lstinputlisting[title=Hilzer's barbershop solution (customer)]


### PR DESCRIPTION
In paragraph 1 of section 5.4.2 - "Hilzer’s barbershop solution" there is a missing word in this sentence:

"I am not if Hilzer had something simpler in mind, but here is the best I could do."
