### PR TITLE
Dining Philosophers: Fix left and right methods

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2885,8 +2885,8 @@ To make it easy for philosophers to refer to their forks,
 we can use the functions {\tt left} and {\tt right}:
 
 \begin{lstlisting}[title={Which fork?}]{}
-def left(i): return i
-def right(i): return (i + 1) % 5
+def left(i): return (i + 1) % 5
+def right(i): return i
 \end{lstlisting}
 
 The {\tt \%} operator wraps around when it gets to 5, so


### PR DESCRIPTION
Fixes the implementation of `left` and `right` methods to be consistent with the definition in `Section 4.4`:

> Similarly, the forks are numbered from 0 to 4, so that Philosopher i has fork i on the right and fork i + 1 on the left