### PR TITLE
fix typo

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -2361,7 +2361,7 @@ It would also be possible to store a reference to {\tt roomEmpty}
 as an attribute of the Lightswitch, rather than pass it as a parameter
 to {\tt lock} and {\tt unlock}.  This alternative would be less
 error-prone, but I think it improves readability if each invocation
-of {\tt lock} and {\tt unlocks} specifies the semaphore it operates on.
+of {\tt lock} and {\tt unlock} specifies the semaphore it operates on.
 
 \subsection{Starvation}
 


### PR DESCRIPTION
An extra s removed! unlocks -> unlock