### PR TITLE
typo fix

### DIFF
--- a/book/book.tex
+++ b/book/book.tex
@@ -3708,7 +3708,7 @@ In other words, the following synchronization constraints apply:
 
 \item Customers invoke the following functions in order:
 {\tt enterShop}, {\tt sitOnSofa},
-{\tt getHairCut}, {\tt pay}.
+{\tt getHairCut}, and {\tt pay}.
 
 \item Barbers invoke {\tt cutHair} and {\tt acceptPayment}.
 

--- a/book/book.tex
+++ b/book/book.tex
@@ -3604,7 +3604,7 @@ arrive immediately invoke {\tt balk}.
 Otherwise each customer signals {\tt customer} and waits on
 {\tt barber}.
 
-Here is the code for barber:
+Here is the code for the barber:
 
 \lstinputlisting[title=Barbershop solution (barber)]{../code/barber.py.2}
 

--- a/book/book.tex
+++ b/book/book.tex
@@ -3271,8 +3271,7 @@ Deadlock!
 \subsection{Smokers problem hint}
 
 The solution proposed by Parnas uses three helper threads
-called ``p
-s'' that respond to the signals from the agent,
+called ``pushers'' that respond to the signals from the agent,
 keep track of the available ingredients, and signal the
 appropriate smoker.
 

--- a/book/book.tex
+++ b/book/book.tex
@@ -3650,7 +3650,7 @@ My solution uses a list of semaphores named {\tt queue}.
 
 \lstinputlisting[title=FIFO barbershop hint]{../code/barber2.py.0}
 
-As each thread passes the turnstile, it creates a thread and puts it
+As each thread passes the turnstile, it creates a semaphore and puts it
 in the queue.
 
 Instead of waiting on {\tt barber}, each thread waits on its own

--- a/book/book.tex
+++ b/book/book.tex
@@ -3806,7 +3806,7 @@ is unnecessary.
 This solution is in \verb"sync_code/barber3.py" (see~\ref{sync.py}).
 
 The only way I can think of to solve this problem is to create a third
-kind of thread, which I can name it an usher.  The ushers manage {\tt queue1}
+kind of thread, which I'll call an usher.  The ushers manage {\tt queue1}
 and the barbers manage {\tt queue2}.  If there are 4 ushers and 3 barbers,
 the sofa can be fully utilized.
 

--- a/book/book.tex
+++ b/book/book.tex
@@ -3534,8 +3534,7 @@ are executed exclusively?
 \clearemptydoublepage
 \section{The barbershop problem}
 
-The original 
-hop problem was proposed by
+The original barbershop problem was proposed by
 Dijkstra.  A variation of it appears in 
 Silberschatz and Galvin's {\em Operating Systems Concepts}
 \cite{silberschatz}.

--- a/book/book.tex
+++ b/book/book.tex
@@ -3271,7 +3271,8 @@ Deadlock!
 \subsection{Smokers problem hint}
 
 The solution proposed by Parnas uses three helper threads
-called ``pushers'' that respond to the signals from the agent,
+called ``p
+s'' that respond to the signals from the agent,
 keep track of the available ingredients, and signal the
 appropriate smoker.
 
@@ -3806,7 +3807,7 @@ is unnecessary.
 This solution is in \verb"sync_code/barber3.py" (see~\ref{sync.py}).
 
 The only way I can think of to solve this problem is to create a third
-kind of thread, which I can an usher.  The ushers manage {\tt queue1}
+kind of thread, which I can name it an usher.  The ushers manage {\tt queue1}
 and the barbers manage {\tt queue2}.  If there are 4 ushers and 3 barbers,
 the sofa can be fully utilized.
 

--- a/book/book.tex
+++ b/book/book.tex
@@ -3534,7 +3534,8 @@ are executed exclusively?
 \clearemptydoublepage
 \section{The barbershop problem}
 
-The original barbershop problem was proposed by
+The original 
+hop problem was proposed by
 Dijkstra.  A variation of it appears in 
 Silberschatz and Galvin's {\em Operating Systems Concepts}
 \cite{silberschatz}.
@@ -3604,7 +3605,7 @@ arrive immediately invoke {\tt balk}.
 Otherwise each customer signals {\tt customer} and waits on
 {\tt barber}.
 
-Here is the code for barbers:
+Here is the code for barber:
 
 \lstinputlisting[title=Barbershop solution (barber)]{../code/barber.py.2}
 


### PR DESCRIPTION
In this [line](https://github.com/AllenDowney/LittleBookOfSemaphores/blob/2d71f16952c88baa69f5dbc8dd6dc1fc9c8b4550/book/book.tex#L3607), `barbers` seems to be `barber`